### PR TITLE
Certbot Renewal Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,9 @@ guardian_listen_webadmin_port: 10443
 # guardian_listen_webadmin_ip: "{{ hostvars[inventory_hostname]['ansible_' ~ guardian_listen_webadmin_interface]['ipv4']['address'] }}"
 
 guardian_access_token: '{{ guardian_access_token_vault }}' # References value defined in guardian.ansible_vault.yml for clarity
+
+# Deploy script to copy certificates and chown them to the Guardian service user account
+deploy_certbot_renewal_hook: true
 ```
 
 ### 6.8. Create an Ansible playbook to deploy

--- a/example/inventory/host_vars/example-guard-1/guardian.yml
+++ b/example/inventory/host_vars/example-guard-1/guardian.yml
@@ -56,3 +56,7 @@ guardian_listen_webadmin_port: 10443
 # guardian_listen_webadmin_ip: "{{ hostvars[inventory_hostname]['ansible_' ~ guardian_listen_webadmin_interface]['ipv4']['address'] }}"
 
 guardian_access_token: '{{ guardian_access_token_vault }}' # References value defined in guardian.ansible_vault.yml for clarity
+
+# Deploy script to copy certificates and chown them to the Guardian service user account
+deploy_certbot_renewal_hook: true
+

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: cubexch
 name: guardian
-version: 1.1.0
+version: 1.1.1
 description: Cube Exchange Guardian Collection
 
 repository: https://github.com/cubexch/ansible-cube-guardian

--- a/roles/guardian/defaults/main.yml
+++ b/roles/guardian/defaults/main.yml
@@ -42,6 +42,9 @@ guardian_dirs:
   config: "/opt/cube-guardian-{{ guardian_instance.guardian_id }}/config"
   log: "/var/log/cube-guardian-{{ guardian_instance.guardian_id }}"
 
+# Deploy script to copy certificates and chown after certbot renewal
+deploy_certbot_renewal_hook: false
+
 guardian_certificates:
   remote_path: "/etc/letsencrypt/live/{{ guardian_instance.public_fqdn }}"
   tls_private_key_name: "privkey.pem"

--- a/roles/guardian/tasks/main.yml
+++ b/roles/guardian/tasks/main.yml
@@ -208,6 +208,23 @@
   notify:
     - Restart guardian service
 
+- name: Deploy certbot renew hook script
+  ansible.builtin.template:
+    src: "certbot-renewal-instance.sh.j2"
+    dest: "{{ guardian_dirs.install }}/current/certbot-renewal-{{ guardian_instance.public_fqdn }}.sh"
+    owner: "{{ guardian_user.name }}"
+    group: "{{ guardian_user.group }}"
+    mode: u=rwx,g=rx,o=-
+  when: deploy_certbot_renewal_hook | default(false) | bool
+
+- name: Configure certbot renew hook
+  community.general.ini_file:
+    path: "/etc/letsencrypt/renewal/{{ guardian_instance.public_fqdn }}.conf"
+    section: "renewalparams"
+    option: "renew_hook"
+    value: "{{ guardian_dirs.install }}/current/certbot-renewal-{{ guardian_instance.public_fqdn }}.sh"
+  when: deploy_certbot_renewal_hook | default(false) | bool
+
 - name: Install iptables if guardian_listen_node_port_open_iptables is true
   ansible.builtin.apt:
     name:

--- a/roles/guardian/templates/certbot-renewal-instance.sh.j2
+++ b/roles/guardian/templates/certbot-renewal-instance.sh.j2
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cp {{ guardian_certificates.remote_path }}/{{ guardian_certificates.tls_private_key_name }} {{ guardian_dirs.config}}/
+cp {{ guardian_certificates.remote_path }}/{{ guardian_certificates.tls_certificate_name }} {{ guardian_dirs.config}}/
+cp {{ guardian_certificates.remote_path }}/{{ guardian_certificates.tls_root_certificate_name }} {{ guardian_dirs.config}}/
+
+chown -R {{ guardian_user.name }}:{{ guardian_user.group }} {{ guardian_dirs.config}}
+
+systemctl restart guardian-{{ guardian_instance.guardian_id }}.service


### PR DESCRIPTION
- Added optional var `deploy_certbot_renewal_hook` to deploy certbot renewal hook script
- Added Ansible task to deploy a templated script to copy certificates to Guardian config directory after successful renewal, and chown them to the proper user
- Added Ansible task to edit the certbot renewal configuration to call the script as a renewal hook