### PR TITLE
Release Guardian au1.6.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: cubexch
 name: guardian
-version: "1.7.3"
+version: "1.7.4"
 description: Cube Exchange Guardian Collection
 
 repository: https://github.com/cubexch/ansible-cube-guardian

--- a/roles/guardian/defaults/main.yml
+++ b/roles/guardian/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for guardian
 
-guardian_version: au1.6.1
+guardian_version: au1.6.2
 guardian_archive_name: aurum-{{ guardian_version }}.tar.gz
 guardian_bin_name: cube-aurum
 guardian_app_environment: production

--- a/roles/guardian/tasks/main.yml
+++ b/roles/guardian/tasks/main.yml
@@ -15,6 +15,8 @@
   ansible.builtin.setup:
     gather_subset:
       - default_ipv4
+  tags:
+    - guardian_config
 
 - name: Create install and config dirs
   ansible.builtin.file:


### PR DESCRIPTION
au1.6.2: Fix dogecoin transaction signature digest edge case
- fixes OP_CODESEPARATOR parsing in script sig for base transaction versions

ansible:
- added tag to enable gathering facts when checking guardian config