### PR TITLE
Guardian au1.10.0 Release

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: cubexch
 name: guardian
-version: "1.8.1"
+version: "1.10.0"
 description: Cube Exchange Guardian Collection
 
 repository: https://github.com/cubexch/ansible-cube-guardian

--- a/roles/guardian/defaults/main.yml
+++ b/roles/guardian/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for guardian
 
-guardian_version: au1.8.0
+guardian_version: au1.10.0
 guardian_archive_name: aurum-{{ guardian_version }}.tar.gz
 guardian_bin_name: cube-aurum
 guardian_app_environment: production

--- a/roles/guardian/tasks/main.yml
+++ b/roles/guardian/tasks/main.yml
@@ -176,19 +176,6 @@
   notify:
     - Restart guardian service
 
-- name: Deploy Guardian Monitor BTC RPC Auth
-  no_log: true
-  ansible.builtin.copy:
-    content: "{{ guardian_monitor.btc.rpc_cookie_file_content }}"
-    dest: "{{ guardian_monitor.btc.rpc_cookie_file }}"
-    owner: "{{ guardian_user.name }}"
-    group: "{{ guardian_user.group }}"
-    mode: u=rw,g=r,o=-
-  when:
-    - guardian_monitor is defined
-  notify:
-    - Restart guardian service
-
 - name: Deploy Service Environment Variables
   no_log: true
   ansible.builtin.template:

--- a/roles/guardian/templates/guardian-instance.service.env.j2
+++ b/roles/guardian/templates/guardian-instance.service.env.j2
@@ -6,6 +6,7 @@ APP_ENV="{{ guardian_app_environment }}"
 GUARDIAN_ID="{{ guardian_instance.guardian_id }}"
 LOG_DIR="{{ guardian_dirs.log }}"
 AURUM_ACCESS_TOKEN="{{ guardian_access_token }}"
+IRIDIUM_JWK="{{ guardian_iridium_jwk_pubkey }}"
 
 
 

--- a/roles/guardian/templates/production-instance.toml.j2
+++ b/roles/guardian/templates/production-instance.toml.j2
@@ -32,7 +32,6 @@ external_url = "{{ guardian.external_url }}"
 [web]
 public_listen_address = "{{ guardian_listen_web_ip }}:{{ guardian_listen_web_port }}"
 admin_listen_address = "{{ guardian_listen_webadmin_ip }}:{{ guardian_listen_webadmin_port }}"
-iridium_jwk = "{{ guardian_iridium_jwk_pubkey }}"
 
 [keys]
 


### PR DESCRIPTION
ansible:
- removed old deployment of btc auth cookie for cube's guardian monitor instance
- moved iridium_jwk from config file to the service's environment variable

aurum v1.10.0:

- shuts down on vault renewal connection failure
- adds backwards-compatible keygen-ack phase after dkg rounds
- adds multi-transaction bitcoin support
- adds initial cosmos support