### PR TITLE
Release Guardian v1.11.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: cubexch
 name: guardian
-version: "1.10.1"
+version: "1.11.0"
 description: Cube Exchange Guardian Collection
 
 repository: https://github.com/cubexch/ansible-cube-guardian

--- a/roles/guardian/defaults/main.yml
+++ b/roles/guardian/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for guardian
 
-guardian_version: au1.10.1
+guardian_version: au1.11.0
 guardian_archive_name: aurum-{{ guardian_version }}.tar.gz
 guardian_bin_name: cube-aurum
 guardian_app_environment: production

--- a/roles/guardian/tasks/main.yml
+++ b/roles/guardian/tasks/main.yml
@@ -186,6 +186,8 @@
     mode: u=rw,g=r,o=-
   notify:
     - Restart guardian service
+  tags:
+    - guardian_config
 
 - name: Deploy Service File
   ansible.builtin.template:
@@ -196,6 +198,8 @@
     mode: ug=rw,o=r
   notify:
     - Restart guardian service
+  tags:
+    - guardian_config
 
 - name: Deploy certbot renew hook script
   ansible.builtin.template:

--- a/roles/guardian/templates/guardian-instance.service.env.j2
+++ b/roles/guardian/templates/guardian-instance.service.env.j2
@@ -13,4 +13,5 @@ IRIDIUM_JWK="{{ guardian_iridium_jwk_pubkey }}"
 {% if guardian_monitor is defined %}
 AURUM_BEARER_TOKEN="{{ guardian_monitor.aurum_bearer_token }}"
 CUBE_PSQL_CONFIG="{{ guardian_monitor.cube_psql_config }}"
+RUN_SNOOP=1
 {% endif %}


### PR DESCRIPTION
au1.11.0

- initializes logging earlier to catch more startup panics
- slightly more runtime-metadata-aware substrate signing